### PR TITLE
Fix sb_pings callback to use a function that returns the comment author ...

### DIFF
--- a/includes/functions/comment_format.php
+++ b/includes/functions/comment_format.php
@@ -172,6 +172,6 @@ if ( !function_exists( 'sb_comments' ) ) {
 if ( !function_exists( 'sb_pings' ) ) {
 	function sb_pings($comment, $args, $depth) {
 		$GLOBALS['comment'] = $comment;
-		echo '<li>' . comment_author_link() . '</li>';
+		echo '<li>' . get_comment_author_link() . '</li>';
 	}
 }


### PR DESCRIPTION
Fix sb_pings callback to use a function that returns the comment author link rather than echoing it.
