### PR TITLE
Makes checking All-<custom_post_type> for custom sidebar replacement work

### DIFF
--- a/includes/extensions/sidebars.php
+++ b/includes/extensions/sidebars.php
@@ -67,8 +67,9 @@ add_action( 'init', 'sb_sidebars_init' );
 function sb_sidebar_default_slug( $data , $postarr ) {
 
 	// If we don't have a post_name (slug), set it to "custom-sidebar"
-	if ( '' == $data['post_name'] ) {
-		$data['post_name'] = 'custom-sidebar';
+	// Make sure this isn't an unsaved post (auto-draft) and is a custon sidebar post
+	if ( 'auto-draft' != $postarr['post_status'] && 'sidebar' == $data['post_type'] && '' == $data['post_name'] ) {
+		$data['post_name'] = 'custom-sidebar-'.$postarr['ID'];
 	}
 
 	// Don't forget to return the data, otherwise we ruin everything.

--- a/includes/extensions/sidebars.php
+++ b/includes/extensions/sidebars.php
@@ -256,7 +256,7 @@ function sb_sidebars_post_type_meta_box( $post, $post_type ) {
 					$get_posts = new WP_Query;
 					$posts = $get_posts->query( $args );
 					if ( $get_posts->post_count ) {
-						$output = '<li><label><input type="checkbox" ' . checked( in_array( 'all-' . $post_type['args']->labels->name, $selected), true, false ) . ' name="post[all-' . $post_type['args']->labels->name .']" value="true"/> All ' . $post_type['args']->labels->name . ' (includes all future ' . $post_type['args']->labels->name . ')</label></li>';
+						$output = '<li><label><input type="checkbox" ' . checked( in_array( 'all-' . $post_type['args']->labels->name, $selected), true, false ) . ' name="post[all-' . $post_type['args']->name .']" value="true"/> All ' . $post_type['args']->labels->name . ' (includes all future ' . $post_type['args']->labels->name . ')</label></li>';
 						if ( $post_type['args']->name == 'page' ) { $output .= '<li><label><input type="checkbox" ' . checked( in_array( 'Home', $selected), true, false ) . ' name="post[Home]" value="true"/>Home</label></li>'; }
 						while ( $get_posts->have_posts() ) : $get_posts->the_post();
 							$output .= '<li>';

--- a/includes/extensions/sidebars.php
+++ b/includes/extensions/sidebars.php
@@ -454,7 +454,7 @@ function sb_sidebars_delete($post_id) {
 	}
 
 }
-add_action( 'trash_post', 'sb_sidebars_delete' );
+add_action( 'trashed_post', 'sb_sidebars_delete' );
 
 /**
  * Filter the "post updated" messages

--- a/includes/extensions/sidebars.php
+++ b/includes/extensions/sidebars.php
@@ -256,7 +256,7 @@ function sb_sidebars_post_type_meta_box( $post, $post_type ) {
 					$get_posts = new WP_Query;
 					$posts = $get_posts->query( $args );
 					if ( $get_posts->post_count ) {
-						$output = '<li><label><input type="checkbox" ' . checked( in_array( 'all-' . $post_type['args']->labels->name, $selected), true, false ) . ' name="post[all-' . $post_type['args']->name .']" value="true"/> All ' . $post_type['args']->labels->name . ' (includes all future ' . $post_type['args']->labels->name . ')</label></li>';
+						$output = '<li><label><input type="checkbox" ' . checked( in_array( 'all-' . $post_type['args']->name, $selected), true, false ) . ' name="post[all-' . $post_type['args']->name .']" value="true"/> All ' . $post_type['args']->labels->name . ' (includes all future ' . $post_type['args']->labels->name . ')</label></li>';
 						if ( $post_type['args']->name == 'page' ) { $output .= '<li><label><input type="checkbox" ' . checked( in_array( 'Home', $selected), true, false ) . ' name="post[Home]" value="true"/>Home</label></li>'; }
 						while ( $get_posts->have_posts() ) : $get_posts->the_post();
 							$output .= '<li>';

--- a/includes/functions/sidebars.php
+++ b/includes/functions/sidebars.php
@@ -226,8 +226,9 @@ class SB_Sidebars {
 			// Determine which key we're testing based on what we're viewing
 			// For our special cases we'll want to return early
 			if ( array_key_exists( 'Home', $custom_sidebars ) && is_front_page() ) { $key = 'Home'; }
-			elseif ( array_key_exists( 'all-Posts', $custom_sidebars ) && is_single() ) { $key = 'all-Posts'; }
+			elseif ( array_key_exists( 'all-Posts', $custom_sidebars ) && is_single() && get_post_type() == 'post' ) ) { $key = 'all-Posts'; }
 			elseif ( array_key_exists( 'all-Pages', $custom_sidebars ) && is_page() ) { $key = 'all-Pages'; }
+			elseif ( array_key_exists( 'all-'.$post->post_type, $custom_sidebars ) && is_single() && get_post_type() == $post->post_type ) { $key = 'all-'.$post->post_type; }
 			elseif ( array_key_exists( 'all-category', $custom_sidebars ) && is_category() ) { $key = 'all-category'; }
 			elseif ( array_key_exists( 'all-tag', $custom_sidebars ) && is_tag() ) { $key = 'all-tag'; }
 			if (

--- a/includes/functions/sidebars.php
+++ b/includes/functions/sidebars.php
@@ -226,7 +226,7 @@ class SB_Sidebars {
 			// Determine which key we're testing based on what we're viewing
 			// For our special cases we'll want to return early
 			if ( array_key_exists( 'Home', $custom_sidebars ) && is_front_page() ) { $key = 'Home'; }
-			elseif ( array_key_exists( 'all-Posts', $custom_sidebars ) && is_single() && get_post_type() == 'post' ) ) { $key = 'all-Posts'; }
+			elseif ( array_key_exists( 'all-Posts', $custom_sidebars ) && is_single() && get_post_type() == 'post' ) { $key = 'all-Posts'; }
 			elseif ( array_key_exists( 'all-Pages', $custom_sidebars ) && is_page() ) { $key = 'all-Pages'; }
 			elseif ( array_key_exists( 'all-'.$post->post_type, $custom_sidebars ) && is_single() && get_post_type() == $post->post_type ) { $key = 'all-'.$post->post_type; }
 			elseif ( array_key_exists( 'all-category', $custom_sidebars ) && is_category() ) { $key = 'all-category'; }


### PR DESCRIPTION
If you were trying to replace sidebars on All of a CPT before (unsuccessfully) you'll need to resave that sidebar's settings.
Also fixes an incorrect hook name for deleting the sidebar transient when a custom sidebar is trashed.
